### PR TITLE
Fix SSL certificate validation and add build/release workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,40 @@
+name: Build and Release
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build and Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Build Windows
+        run: |
+          GOOS=windows GOARCH=amd64 go build -o zteOnu_windows_amd64.exe .
+
+      - name: Build Linux
+        run: |
+          GOOS=linux GOARCH=amd64 go build -o zteOnu_linux_amd64 .
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: insecure-build
+          files: |
+            zteOnu_windows_amd64.exe
+            zteOnu_linux_amd64
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/app/factory/factory.go
+++ b/app/factory/factory.go
@@ -1,9 +1,11 @@
 package factory
 
 import (
+	"crypto/tls"
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -20,8 +22,14 @@ func New(user string, passwd string, ip string, port int) *Factory {
 		passwd: passwd,
 		ip:     ip,
 		port:   port,
-		cli: resty.New().SetHeader("User-Agent", "curl/8.8.0-DEV").
-			SetBaseURL(fmt.Sprintf("http://%s:%d", ip, port)),
+		cli: resty.New().
+			SetHeader("User-Agent", "curl/8.8.0-DEV").
+			SetBaseURL(fmt.Sprintf("http://%s:%d", ip, port)).
+			SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true}).
+			SetRedirectPolicy(resty.FlexibleRedirectPolicy(10)).
+			SetTransport(&http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			}),
 	}
 }
 


### PR DESCRIPTION
- Modified `app/factory/factory.go` to support SSL by setting `InsecureSkipVerify: true` on the resty client.
- Added a flexible redirect policy to handle HTTP to HTTPS transitions.
- Created `.github/workflows/build-release.yml` to automate builds for Windows and Linux and release them as assets for the `insecure-build` tag on every push to master.